### PR TITLE
fix precision conversion warning

### DIFF
--- a/YTVimeoExtractor/YTVimeoExtractor.m
+++ b/YTVimeoExtractor/YTVimeoExtractor.m
@@ -107,7 +107,7 @@ NSString *const YTVimeoExtractorErrorDomain = @"YTVimeoExtractorErrorDomain";
         [connection cancel];
     }
     
-    NSUInteger capacity = (response.expectedContentLength != NSURLResponseUnknownLength) ? response.expectedContentLength : 0;
+    NSUInteger capacity = (response.expectedContentLength != NSURLResponseUnknownLength) ? (uint)response.expectedContentLength : 0;
     self.buffer = [[NSMutableData alloc] initWithCapacity:capacity];
 }
 


### PR DESCRIPTION
This silents the warning

```
YTVimeoExtractor/YTVimeoExtractor/YTVimeoExtractor.m:110:92: Implicit conversion loses integer precision: 'long long' to 'NSUInteger' (aka 'unsigned int')
```

on xcode 5
