### PR TITLE
Allow custom referer to work with Vimeo privacy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Use the block based methods and pass it the video url and the desired quality
 }];
 ```
 
-or create an instance of YTVimeoExtractor
+or create an instance of YTVimeoExtractor.
 
 ```objc
 self.extractor = [[YTVimeoExtractor alloc] initWithURL:@"http://vimeo.com/58600663" quality:YTVimeoVideoQualityMedium];
@@ -60,6 +60,25 @@ and implement YTVimeoExtractor delegate methods in your ViewController.
 {
     // handle error
 }
+```
+
+If the Vimeo videos have domain-level restrictions and can only be played from particular domains, it's easy to add a referer:
+
+```objc
+[YTVimeoExtractor fetchVideoURLFromURL:@"http://vimeo.com/58600663"
+                               quality:YTVimeoVideoQualityMedium
+                               referer:@"http://www.mywebsite.com"
+                     completionHandler:^(NSURL *videoURL, NSError *error, YTVimeoVideoQuality quality) {
+    if (error) {
+        // handle error
+        NSLog(@"Video URL: %@", [videoURL absoluteString]);
+    } else {
+        // run player
+        self.playerViewController = [[MPMoviePlayerViewController alloc] initWithContentURL:videoURL];
+        [self.playerViewController.moviePlayer prepareToPlay];
+        [self presentViewController:self.playerViewController animated:YES completion:nil];
+    }
+}];
 ```
 
 Check the sample application for more details.

--- a/YTVimeoExtractor/YTVimeoExtractor.h
+++ b/YTVimeoExtractor/YTVimeoExtractor.h
@@ -31,15 +31,20 @@ typedef void (^completionHandler) (NSURL *videoURL, NSError *error, YTVimeoVideo
 
 @property (nonatomic, readonly) BOOL running;
 @property (nonatomic, readonly) YTVimeoVideoQuality quality;
+@property (nonatomic, readonly) NSString* referer;
 @property (strong, nonatomic, readonly) NSURL *vimeoURL;
 
 @property (unsafe_unretained, nonatomic) id<YTVimeoExtractorDelegate> delegate;
 
 + (void)fetchVideoURLFromURL:(NSString *)videoURL quality:(YTVimeoVideoQuality)quality completionHandler:(completionHandler)handler;
 + (void)fetchVideoURLFromID:(NSString *)videoURL quality:(YTVimeoVideoQuality)quality completionHandler:(completionHandler)handler;
++ (void)fetchVideoURLFromURL:(NSString *)videoURL quality:(YTVimeoVideoQuality)quality referer:(NSString *)referer completionHandler:(completionHandler)handler;
++ (void)fetchVideoURLFromID:(NSString *)videoURL quality:(YTVimeoVideoQuality)quality referer:(NSString *)referer completionHandler:(completionHandler)handler;
 
 - (id)initWithURL:(NSString *)videoURL quality:(YTVimeoVideoQuality)quality;
 - (id)initWithID:(NSString *)videoID quality:(YTVimeoVideoQuality)quality;
+- (id)initWithURL:(NSString *)videoURL quality:(YTVimeoVideoQuality)quality referer:(NSString *)referer;
+- (id)initWithID:(NSString *)videoID quality:(YTVimeoVideoQuality)quality referer:(NSString *)referer;
 
 - (void)start;
 


### PR DESCRIPTION
Vimeo Plus and PRO members have the option to add domain-level restrictions to their videos. Many of our customers at [Zaption](http://www.zaption.com) have done this with videos they uploaded to our web app. Now, those videos cannot be extracted by YTVimeoExtractor on mobile, because the referer doesn't match and therefore playback is restricted.

This update allows users of YTVimeoExtractor to add a custom referer to work with these restrictions.
