### PR TITLE
Updated for new Vimeo API response format, added best available quality

### DIFF
--- a/YTVimeoExtractor/YTVimeoExtractor.h
+++ b/YTVimeoExtractor/YTVimeoExtractor.h
@@ -20,7 +20,8 @@ enum {
 typedef enum YTVimeoVideoQuality : NSUInteger {
     YTVimeoVideoQualityLow,
     YTVimeoVideoQualityMedium,
-    YTVimeoVideoQualityHigh
+    YTVimeoVideoQualityHigh,
+	YTVimeoVideoQualityBestAvailable
 }YTVimeoVideoQuality;
 
 typedef void (^completionHandler) (NSURL *videoURL, NSError *error, YTVimeoVideoQuality quality);


### PR DESCRIPTION
Fix for issue #24.

I've used the code provided by @Chris59160 and tidied it up a bit.

I found myself requiring the best available video quality, so I've added code to facilitate this, too. I feel this is a common requirement for users of this code.