### PR TITLE
Add 10.9 requirement to podspec

### DIFF
--- a/YTVimeoExtractor.podspec
+++ b/YTVimeoExtractor.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/lilfaf/YTVimeoExtractor.git", :tag => "0.2.0" }
 
   s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.8'
+  s.osx.deployment_target = '10.9'
   s.tvos.deployment_target = '9.0'
   s.source_files = 'YTVimeoExtractor/*.{h,m}'
   s.requires_arc = true


### PR DESCRIPTION
NSURLSession is available on 10.9 or later the pod spec previously had 10.8.