### PR TITLE
Fix memory leak by invalidating the NSURLSession when finished

### DIFF
--- a/YTVimeoExtractor/YTVimeoExtractorOperation.m
+++ b/YTVimeoExtractor/YTVimeoExtractorOperation.m
@@ -115,18 +115,18 @@ NSString *const YTVimeoPlayerConfigURL = @"https://player.vimeo.com/video/%@/con
 }
 
 -(void)finishOperationWithError:(NSError *)error{
-    
     _error = error;
     [self finish];
-    
+    [self.networkSession invalidateAndCancel];
 }
 
 -(void)finishOperationWithVideo:(YTVimeoVideo *)video{
-    
     _operationVideo = video;
     _error = nil;
     [self finish];
+    [self.networkSession finishTasksAndInvalidate];
 }
+
 - (void)finish
 {
     self.isExecuting = NO;


### PR DESCRIPTION
NSURLSession keeps a strong reference to its delegate, so it's necessary to invalidate the session in order to break the cycle.